### PR TITLE
feat: add chainfile argument to Converter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agct"
-version = "0.1.0-dev0"
+version = "0.1.0-dev1"
 authors = [
     {name = "James Stevenson"}
 ]

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,21 @@
+"""Module for testing Converter initialization"""
+import pytest
+from tests.conftest import DATA_DIR
+
+from agct import Converter, Genome
+
+
+def test_valid():
+    """Test valid initialization"""
+    assert Converter(
+        chainfile=str(DATA_DIR / "ucsc-chainfile" / "chainfile_hg19_to_hg38_.chain")
+    )
+
+
+def test_invalid():
+    """Test invalid initialization"""
+    with pytest.raises(ValueError, match="Must provide both `from_db` and `to_db`"):
+        Converter()
+
+    with pytest.raises(ValueError, match="Liftover must be to/from different sources."):
+        Converter(Genome.HG19, Genome.HG19)


### PR DESCRIPTION
close #22 

Changes:
* Adds `chainfile` argument to `Converter` so that we can point to local file and not have to make any calls to wags-tails
* I removed type checks for `to_db` and `from_db` since the signature states they should be of type `Genome`