### PR TITLE
chore: bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agct"
-version = "0.1.0-dev2"
+version = "0.1.1"
 authors = [
     {name = "James Stevenson"},
     {name = "Kori Kuzma"},


### PR DESCRIPTION
I'm trying to figure out an issue with the maturin release workflow on another project, and wanted to use this one as a reference. However, it's been too long since the last release, so the action metadata has been deleted.

This release shouldn't add any new functionality -- it's just gonna be some small CICD and style stuff -- so it shouldn't have any deleterious changes (knock on wood)